### PR TITLE
Specificy MSRV at 1.70

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["project", "tui", "terminal", "manager", "files"]
 categories = ["command-line-utilities", "filesystem"]
 license = "MIT"
 edition = "2021"
+rust-version = "1.70"
 
 [[bench]]
 name = "listing_selection"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Here are just a few builtin things projectable can do:
 
 To get started, you can use one of the following installation methods:
 
+### Minimum Supported Rust Version (MSRV)
+When installing from Cargo or building from source, the MSRV for `projectable` is currently 1.70.x
+
 <details>
   <summary><a href="https://crates.io">cargo</a></summary>
 


### PR DESCRIPTION
`is_some_and` was only recently stabilized, so 1.70 is needed to build on stable.