### PR TITLE
merge more config file settings into config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -282,16 +282,17 @@ impl Merge for Config {
             help,
             down,
             up,
+            open,
             all_down,
             all_up,
-            open,
+            kill_processes,
             selected,
             popup_border_style,
             help_key_style,
-            kill_processes,
             commands,
-            esc_to_close,
-            exec_cmd
+            exec_cmd,
+            editor_cmd,
+            esc_to_close
         );
         self.special_commands.merge(other.special_commands);
         self.preview.merge(other.preview);


### PR DESCRIPTION
When I tried setting `editor_cmd` in my `.projectable.toml` file.. expecting it to override both the default `vi` and `$EDITOR` env.

It doesn't get used by the application.

This PR adds a few "missing" fields to the merge part of the configuration.

If these are omitted by design.. please feel free to discard this PR.

NOTE: this change gives (local) config precedence over env which might not be what is desired. Maybe the order of evaluation should be 1): env -> local config -> global config -> default
With this PR it appears to become 2): local config -> global config -> env -> default
Without this PR it is 3): env -> default


