### PR TITLE
Merge entries within the 'commands' config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -289,11 +289,11 @@ impl Merge for Config {
             selected,
             popup_border_style,
             help_key_style,
-            commands,
             exec_cmd,
             editor_cmd,
             esc_to_close
         );
+        self.commands.merge(other.commands);
         self.special_commands.merge(other.special_commands);
         self.preview.merge(other.preview);
         self.filetree.merge(other.filetree);


### PR DESCRIPTION
Merge entries in the 'commands' config when loading multiple files (rather than replacing it / dropping existing entries).

With this change, if you have a `~/.config/projectable/config.toml` file that contains...

```
[commands]
"ctrl-t" = "echo hey there"
"ctrl-y" = "echo this is a demo"
```

and then a `$PWD/.projectable.toml` file that contains...

```
[commands]
"ctrl-t" = "echo this is replaced"
"ctrl-u" = "echo this is another command"
```

Then when you run `prj` in that `$PWD` (or below), you'll get three commands: one for `ctrl-t`, one for `ctrl-y`, and one for `ctrl-u`. The command bound to `ctrl-t` will be the one that in this example says "replaced".

Previously, the whole command map was getting replaced, which meant in this scenario you'd only end up with `ctrl-t` and `ctrl-u` (the `ctrl-y` command from the parent config just got discarded).

I suppose this could be considered a breaking change, but for me, it's what I expected when I first read the docs about the built-in configuration merging, so hopefully it's inline with the intentions of the project :)